### PR TITLE
Initial charts to deploy basex-validator to elife staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/charts/*.tgz

--- a/helm/basex-validator/Chart.yaml
+++ b/helm/basex-validator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 'latest'
+appVersion: latest
 description: BaseX Validator for validating XML against eLife's schematron
 name: basex-validator
 version: 0.1.0

--- a/helm/basex-validator/Chart.yaml
+++ b/helm/basex-validator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: 'latest'
+description: BaseX Validator for validating XML against eLife's schematron
+name: basex-validator
+version: 0.1.0

--- a/helm/basex-validator/templates/_helpers.tpl
+++ b/helm/basex-validator/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "basex-validator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "basex-validator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "basex-validator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/helm/basex-validator/templates/_helpers.tpl
+++ b/helm/basex-validator/templates/_helpers.tpl
@@ -1,32 +1,6 @@
-{{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "basex-validator.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "basex-validator.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "basex-validator.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
 {{- end -}}

--- a/helm/basex-validator/templates/deployment.yaml
+++ b/helm/basex-validator/templates/deployment.yaml
@@ -1,28 +1,28 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: {{ include "basex-validator.fullname" . }}
+  name: {{ .Release.Name }}
   labels:
-    app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     helm.sh/chart: {{ include "basex-validator.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+      app.kubernetes.io/name: {{ .Chart.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+        app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.images.repository }}:{{ .Values.images.tag }}"
-          imagePullPolicy: {{ .Values.images.pullPolicy }}
+        - name: app
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             requests:
               memory: '512Mi'

--- a/helm/basex-validator/templates/deployment.yaml
+++ b/helm/basex-validator/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: { { include "basex-validator.fullname" . } }
+  labels:
+    app.kubernetes.io/name: { { include "basex-validator.name" . } }
+    helm.sh/chart: { { include "basex-validator.chart" . } }
+    app.kubernetes.io/instance: { { .Release.Name } }
+    app.kubernetes.io/managed-by: { { .Release.Service } }
+spec:
+  replicas: { { .Values.replicaCount } }
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: { { include "basex-validator.name" . } }
+      app.kubernetes.io/instance: { { .Release.Name } }
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: { { include "basex-validator.name" . } }
+        app.kubernetes.io/instance: { { .Release.Name } }
+    spec:
+      containers:
+        - name: { { .Chart.Name } }
+          image: '{{ .Values.images.repository }}:{{ .Values.images.tag }}'
+          imagePullPolicy: { { .Values.images.pullPolicy } }
+          resources:
+            requests:
+              memory: '512Mi'
+          ports:
+            - name: http
+              containerPort: 8984
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+          readinessProbe:
+            tcpSocket:
+              port: http

--- a/helm/basex-validator/templates/deployment.yaml
+++ b/helm/basex-validator/templates/deployment.yaml
@@ -1,28 +1,28 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: { { include "basex-validator.fullname" . } }
+  name: {{ include "basex-validator.fullname" . }}
   labels:
-    app.kubernetes.io/name: { { include "basex-validator.name" . } }
-    helm.sh/chart: { { include "basex-validator.chart" . } }
-    app.kubernetes.io/instance: { { .Release.Name } }
-    app.kubernetes.io/managed-by: { { .Release.Service } }
+    app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+    helm.sh/chart: {{ include "basex-validator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: { { .Values.replicaCount } }
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: { { include "basex-validator.name" . } }
-      app.kubernetes.io/instance: { { .Release.Name } }
+      app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: { { include "basex-validator.name" . } }
-        app.kubernetes.io/instance: { { .Release.Name } }
+        app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-        - name: { { .Chart.Name } }
-          image: '{{ .Values.images.repository }}:{{ .Values.images.tag }}'
-          imagePullPolicy: { { .Values.images.pullPolicy } }
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.images.repository }}:{{ .Values.images.tag }}"
+          imagePullPolicy: {{ .Values.images.pullPolicy }}
           resources:
             requests:
               memory: '512Mi'

--- a/helm/basex-validator/templates/service.yaml
+++ b/helm/basex-validator/templates/service.yaml
@@ -1,28 +1,24 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "basex-validator.fullname" . }}
+  name: {{ .Release.Name }}
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: {{ include "basex-validator.fullname" . }}.elifesciences.org
+    external-dns.alpha.kubernetes.io/hostname: {{ .Release.Name }}.elifesciences.org
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.clientCertificate }}
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
   labels:
-    app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     helm.sh/chart: {{ include "basex-validator.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: LoadBalancer
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
     - name: https
       port: 443
       protocol: TCP
       targetPort: http
   selector:
-    app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/basex-validator/templates/service.yaml
+++ b/helm/basex-validator/templates/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "basex-validator.fullname" . }}
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: {{ include "basex-validator.fullname" . }}.elifesciences.org
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.clientCertificate }}
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+  labels:
+    app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+    helm.sh/chart: {{ include "basex-validator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: {{ include "basex-validator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/basex-validator/values.yaml
+++ b/helm/basex-validator/values.yaml
@@ -2,17 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
-images:
+image:
   tag: latest
   pullPolicy: Always
   repository: elifesciences/basex-validator
 
 clientCertificate: 'arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/2019.wildcard.elifesciences.org'
-
-nameOverride: ''
-fullnameOverride: ''
-
-service:
-  port: 8984

--- a/helm/basex-validator/values.yaml
+++ b/helm/basex-validator/values.yaml
@@ -1,0 +1,18 @@
+# Default values for jats-validator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+images:
+  tag: latest
+  pullPolicy: Always
+  repository: elifesciences/basex-validator
+
+clientCertificate: 'arn:aws:iam::512686554592:server-certificate/cloudfront/wildcard.elifesciences.org/2019.wildcard.elifesciences.org'
+
+nameOverride: ''
+fullnameOverride: ''
+
+service:
+  port: 8984


### PR DESCRIPTION
Created an initial set of chats that can be used to deploy to the elife staging system, and I guess also the production environment when ready.

I've already used these to manually deploy the container, so know that they work. Want to get committed so that I can start getting them deployed from the CI.